### PR TITLE
Changed Rclone sync log format

### DIFF
--- a/py_modules/sync_target.py
+++ b/py_modules/sync_target.py
@@ -168,7 +168,7 @@ class _SyncTarget:
                 "--log-file",
                 str(self._get_rclone_log_path()),
                 "--log-format",
-                "none",
+                "nolevel",
             ]
         )
 


### PR DESCRIPTION
When trying to sync with Rclone I got this error:

> Error: invalid argument "none" for "--log-format" flag: parsing "none" as fs.Bits[github.com/rclone/rclone/fs/log.logFormatChoices] failed: invalid choice "none" from: date, time, microseconds, UTC, longfile, shortfile, pid, nolevel, json

Looking at [docs](https://rclone.org/docs/#log-format-list) there's really no `none` option.
I tried manually changing `~/homebrew/plugins/SDH-GameSync/py_modules/sync_target.py` to `nolevel` (that felt closest to `none`) and after a restart the sync worked again.

I guess if it worked before Rclone now must be validating the option.
Opening this PR with the change, let me know if it makes sense.